### PR TITLE
docs: add CLAUDE.md and .claude/ project structure

### DIFF
--- a/.claude/agents/rails-reviewer.md
+++ b/.claude/agents/rails-reviewer.md
@@ -1,0 +1,28 @@
+---
+name: rails-reviewer
+description: Review a diff or branch for this Pubquiz app's Rails / Hotwire / Devise conventions. Use after implementing a change, before commit.
+tools: Read, Grep, Glob, Bash
+---
+
+You review changes in the Pubquiz Rails 7.1 app. Focus on the conventions this codebase
+actually uses — flag deviations, don't invent new rules.
+
+Check for:
+- **Enums & state flow** — Game/Round/TeamAnswer state changes go through the defined enum
+  states and bang actions (`start!`, `next_round!`, `process_results!`, `show_results!`),
+  not ad-hoc column writes.
+- **Real-time** — model changes that should reflect live use `Turbo::Broadcastable` /
+  Turbo Streams; controllers respond with streams, not full reloads, where the rest do.
+- **`RelationshipUpdatable`** — child-record count logic reuses the concern instead of
+  duplicating create/destroy loops.
+- **Auth** — new controller actions enforce `authenticate_user!` (only `games#join` is public).
+- **UUID PKs** — no code assumes integer IDs / ordering by id.
+- **Views** — new templates are Slim; JS goes through Stimulus controllers, not inline scripts.
+- **Tests** — new behavior has Minitest coverage; fixtures updated.
+- **Style** — passes `bundle exec standard`.
+
+Output findings as [Conventional Comments](https://conventionalcomments.org):
+`<label> [decorations]: <subject>` where label is one of `praise`, `nitpick`, `suggestion`,
+`issue`, `question`, `thought`, `chore`. Prefix each with its `path:line`. Mark non-blocking
+notes `(non-blocking)`. No scope creep.
+Run `git diff` (or against the named branch) to get the changes if not provided.

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,7 @@
+---
+description: Start the dev server (web + JS watch)
+---
+
+Start the app with `bin/dev`, which runs the Puma web server and the esbuild `--watch`
+JS build together via `Procfile.dev`. Ensure Postgres and Redis are running first
+(or `docker-compose up`).

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,8 @@
+---
+description: Lint with StandardRB
+---
+
+Run `bundle exec standard`. If `$ARGUMENTS` contains `fix`, run `bundle exec standard --fix`
+instead and summarize what changed. Report remaining offenses concisely.
+
+`$ARGUMENTS`

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,9 @@
+---
+description: Run the Minitest suite (optionally scoped to a path)
+---
+
+Run the test suite with `bin/rails test`. If `$ARGUMENTS` is given, scope to that path or
+file (e.g. `test/models/game_test.rb`). For system tests use `bin/rails test:system`.
+Report failures with the relevant output; do not silently skip.
+
+`$ARGUMENTS`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle install *)",
+      "Bash(bundle exec *)",
+      "Bash(bin/rails test*)",
+      "Bash(bin/rails db:*)",
+      "Bash(npm run build*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-debug.log*
 .yarn-integrity
 
 /.idea
+
+# Personal (per-developer) Claude Code settings. Shared settings live in .claude/settings.json.
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Overview
+
+Pubquiz is a Rails app to host and manage a pub quiz. A user creates a **Game**, which
+contains **Rounds**, which contain **Questions**. **Teams** join a game and submit a
+**TeamAnswer** per question; the host scores answers and results are shown live.
+
+Hierarchy: `Game → Round → Question` and `Game → Team → TeamAnswer`.
+
+## Stack
+
+- **Ruby** 3.4.9 (`.ruby-version`), **Rails** 7.1.6
+- **PostgreSQL** — UUID primary keys throughout (pgcrypto)
+- **Redis** — caching / sessions / ActionCable
+- **Puma** web server
+- **Hotwire**: Turbo + Stimulus, **ActionCable** for real-time updates
+- **esbuild** bundles JS (no Webpacker); **sassc-rails** for CSS
+- **Slim** view templates
+- **Devise** authentication
+- **StandardRB** for linting/formatting
+
+## Commands
+
+```bash
+bin/setup            # install deps + prepare DB
+bin/dev              # run web + JS watch (Procfile.dev)
+bin/rails test       # run Minitest suite (append a path to scope)
+bin/rails test:system # system tests (Capybara + Selenium)
+bundle exec standard # lint
+bundle exec standard --fix # autofix
+npm run build        # one-off JS build (bin/dev runs --watch)
+docker-compose up    # Postgres + Redis if not running locally
+```
+
+## Architecture & conventions
+
+- **State via enums:**
+  - `Game`: `pending_start`, `started`, `pending_results`, `finished`
+  - `Round`: `pending_start`, `started`, `finished`, `scored`
+  - `TeamAnswer`: `pending`, `correct`, `incorrect`
+- **Game flow actions:** `start!`, `next_round!`, `process_results!`, `show_results!`
+  (custom member routes on `games`).
+- **Real-time:** `Game`, `Round`, `Team` include `Turbo::Broadcastable` and broadcast over
+  ActionCable; controllers respond with Turbo Streams (partial replacement, not full reloads).
+- **`RelationshipUpdatable` concern** (`app/models/concerns/`) — auto creates/destroys child
+  records to match a count (e.g. N questions per round, N teams per game).
+- **Auth:** Devise. `authenticate_user!` is required everywhere except `games#join` (GET).
+- **Views are Slim** (`app/views/**/*.slim`). Stimulus controllers live in
+  `app/javascript/controllers/`, ActionCable channels in `app/javascript/channels/`.
+
+## Commits & reviews
+
+- **Commits:** always use [Conventional Commits](https://www.conventionalcommits.org) —
+  `type(scope): subject` (e.g. `feat(games): add live scoring`, `fix(rounds): correct enum guard`).
+  Types: `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `refactor`, `perf`, `test`, `style`.
+  Breaking changes use `!` (e.g. `build(deps)!: upgrade to Rails 7.1`).
+- **Reviews:** always use [Conventional Comments](https://conventionalcomments.org) —
+  `<label> [decorations]: <subject>`. Labels: `praise`, `nitpick`, `suggestion`, `issue`,
+  `question`, `thought`, `chore`. Mark non-blocking notes `(non-blocking)`.
+- **No AI attribution:** never add `Co-Authored-By: Claude` (or any Claude/AI attribution)
+  to commit messages, and never add "Generated with Claude Code" to PR descriptions.
+
+## Testing
+
+- **Minitest** with fixtures; tests run in parallel.
+- Layout: `test/models/`, `test/controllers/`, `test/system/`, `test/channels/`.
+- System tests use Capybara + Selenium.
+
+## Gotchas
+
+- Needs a local **Postgres** role `pubquiz` / `pubquiz` and **Redis** running — or use
+  `docker-compose up`.
+- All tables use **UUID** primary keys; don't assume integer IDs.
+- `config/master.key` is gitignored — credentials won't decrypt without it.


### PR DESCRIPTION
## Context

No `CLAUDE.md` or standards-aligned `.claude/` setup existed. This adds a project guide and tooling so Claude Code (and teammates) know the stack, commands, and conventions without re-discovering them each session. Documents the post-upgrade stack (Rails 7.1 / Ruby 3.4.9 / esbuild), so it bases on `upgrade/rails-7.1-ruby-3.4`.

## Changes

- **`CLAUDE.md`** — overview, stack, commands, architecture & conventions, testing, gotchas.
- **`.claude/settings.json`** — shared, team-wide permission allow-rules (committed).
- **`.claude/settings.local.json`** — trimmed to personal entries; now gitignored.
- **`.claude/commands/`** — project slash commands: `/test`, `/lint`, `/dev`.
- **`.claude/agents/rails-reviewer.md`** — reviewer agent for this app's Rails/Hotwire/Devise conventions.
- **`.gitignore`** — ignore `/.claude/settings.local.json`.

Establishes **Conventional Commits** for commits and **Conventional Comments** for reviews.

## Verification

- `git check-ignore .claude/settings.local.json` confirms it's ignored.
- `/test`, `/lint`, `/dev` resolve in a new session.
- Documented `bin/rails test` / `bundle exec standard` not run here (need Postgres + Redis).