### PR TITLE
fix(security): game ownership + auth gaps + logic bugs

### DIFF
--- a/.claude/agents/rails-reviewer.md
+++ b/.claude/agents/rails-reviewer.md
@@ -1,0 +1,28 @@
+---
+name: rails-reviewer
+description: Review a diff or branch for this Pubquiz app's Rails / Hotwire / Devise conventions. Use after implementing a change, before commit.
+tools: Read, Grep, Glob, Bash
+---
+
+You review changes in the Pubquiz Rails 7.1 app. Focus on the conventions this codebase
+actually uses — flag deviations, don't invent new rules.
+
+Check for:
+- **Enums & state flow** — Game/Round/TeamAnswer state changes go through the defined enum
+  states and bang actions (`start!`, `next_round!`, `process_results!`, `show_results!`),
+  not ad-hoc column writes.
+- **Real-time** — model changes that should reflect live use `Turbo::Broadcastable` /
+  Turbo Streams; controllers respond with streams, not full reloads, where the rest do.
+- **`RelationshipUpdatable`** — child-record count logic reuses the concern instead of
+  duplicating create/destroy loops.
+- **Auth** — new controller actions enforce `authenticate_user!` (only `games#join` is public).
+- **UUID PKs** — no code assumes integer IDs / ordering by id.
+- **Views** — new templates are Slim; JS goes through Stimulus controllers, not inline scripts.
+- **Tests** — new behavior has Minitest coverage; fixtures updated.
+- **Style** — passes `bundle exec standard`.
+
+Output findings as [Conventional Comments](https://conventionalcomments.org):
+`<label> [decorations]: <subject>` where label is one of `praise`, `nitpick`, `suggestion`,
+`issue`, `question`, `thought`, `chore`. Prefix each with its `path:line`. Mark non-blocking
+notes `(non-blocking)`. No scope creep.
+Run `git diff` (or against the named branch) to get the changes if not provided.

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,7 @@
+---
+description: Start the dev server (web + JS watch)
+---
+
+Start the app with `bin/dev`, which runs the Puma web server and the esbuild `--watch`
+JS build together via `Procfile.dev`. Ensure Postgres and Redis are running first
+(or `docker-compose up`).

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,8 @@
+---
+description: Lint with StandardRB
+---
+
+Run `bundle exec standard`. If `$ARGUMENTS` contains `fix`, run `bundle exec standard --fix`
+instead and summarize what changed. Report remaining offenses concisely.
+
+`$ARGUMENTS`

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,9 @@
+---
+description: Run the Minitest suite (optionally scoped to a path)
+---
+
+Run the test suite with `bin/rails test`. If `$ARGUMENTS` is given, scope to that path or
+file (e.g. `test/models/game_test.rb`). For system tests use `bin/rails test:system`.
+Report failures with the relevant output; do not silently skip.
+
+`$ARGUMENTS`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle install *)",
+      "Bash(bundle exec *)",
+      "Bash(bin/rails test*)",
+      "Bash(bin/rails db:*)",
+      "Bash(npm run build*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-debug.log*
 .yarn-integrity
 
 /.idea
+
+# Personal (per-developer) Claude Code settings. Shared settings live in .claude/settings.json.
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Overview
+
+Pubquiz is a Rails app to host and manage a pub quiz. A user creates a **Game**, which
+contains **Rounds**, which contain **Questions**. **Teams** join a game and submit a
+**TeamAnswer** per question; the host scores answers and results are shown live.
+
+Hierarchy: `Game → Round → Question` and `Game → Team → TeamAnswer`.
+
+## Stack
+
+- **Ruby** 3.4.9 (`.ruby-version`), **Rails** 7.1.6
+- **PostgreSQL** — UUID primary keys throughout (pgcrypto)
+- **Redis** — caching / sessions / ActionCable
+- **Puma** web server
+- **Hotwire**: Turbo + Stimulus, **ActionCable** for real-time updates
+- **esbuild** bundles JS (no Webpacker); **sassc-rails** for CSS
+- **Slim** view templates
+- **Devise** authentication
+- **StandardRB** for linting/formatting
+
+## Commands
+
+```bash
+bin/setup            # install deps + prepare DB
+bin/dev              # run web + JS watch (Procfile.dev)
+bin/rails test       # run Minitest suite (append a path to scope)
+bin/rails test:system # system tests (Capybara + Selenium)
+bundle exec standard # lint
+bundle exec standard --fix # autofix
+npm run build        # one-off JS build (bin/dev runs --watch)
+docker-compose up    # Postgres + Redis if not running locally
+```
+
+## Architecture & conventions
+
+- **State via enums:**
+  - `Game`: `pending_start`, `started`, `pending_results`, `finished`
+  - `Round`: `pending_start`, `started`, `finished`, `scored`
+  - `TeamAnswer`: `pending`, `correct`, `incorrect`
+- **Game flow actions:** `start!`, `next_round!`, `process_results!`, `show_results!`
+  (custom member routes on `games`).
+- **Real-time:** `Game`, `Round`, `Team` include `Turbo::Broadcastable` and broadcast over
+  ActionCable; controllers respond with Turbo Streams (partial replacement, not full reloads).
+- **`RelationshipUpdatable` concern** (`app/models/concerns/`) — auto creates/destroys child
+  records to match a count (e.g. N questions per round, N teams per game).
+- **Auth:** Devise. `authenticate_user!` is required everywhere except `games#join` (GET).
+- **Views are Slim** (`app/views/**/*.slim`). Stimulus controllers live in
+  `app/javascript/controllers/`, ActionCable channels in `app/javascript/channels/`.
+
+## Commits & reviews
+
+- **Commits:** always use [Conventional Commits](https://www.conventionalcommits.org) —
+  `type(scope): subject` (e.g. `feat(games): add live scoring`, `fix(rounds): correct enum guard`).
+  Types: `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `refactor`, `perf`, `test`, `style`.
+  Breaking changes use `!` (e.g. `build(deps)!: upgrade to Rails 7.1`).
+- **Reviews:** always use [Conventional Comments](https://conventionalcomments.org) —
+  `<label> [decorations]: <subject>`. Labels: `praise`, `nitpick`, `suggestion`, `issue`,
+  `question`, `thought`, `chore`. Mark non-blocking notes `(non-blocking)`.
+- **No AI attribution:** never add `Co-Authored-By: Claude` (or any Claude/AI attribution)
+  to commit messages, and never add "Generated with Claude Code" to PR descriptions.
+
+## Testing
+
+- **Minitest** with fixtures; tests run in parallel.
+- Layout: `test/models/`, `test/controllers/`, `test/system/`, `test/channels/`.
+- System tests use Capybara + Selenium.
+
+## Gotchas
+
+- Needs a local **Postgres** role `pubquiz` / `pubquiz` and **Redis** running — or use
+  `docker-compose up`.
+- All tables use **UUID** primary keys; don't assume integer IDs.
+- `config/master.key` is gitignored — credentials won't decrypt without it.

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,17 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    # All pages that open a cable connection (games#show, teams#show) sit behind
+    # `authenticate_user!`, so an unauthenticated socket has no legitimate use.
+    def find_verified_user
+      env["warden"]&.user || reject_unauthorized_connection
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  private
+
+  # Halts the action unless the signed-in user owns the given game.
+  # Responds 404 (not 403) so resource existence isn't leaked.
+  def require_game_owner!(game)
+    return if game && user_signed_in? && game.user_id == current_user.id
+
+    respond_to do |format|
+      format.html { redirect_to root_path, alert: "Not authorized." }
+      format.any { head :not_found }
+    end
+  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,10 +1,11 @@
 class GamesController < ApplicationController
-  before_action :set_game, only: [:show, :update, :destroy, :edit, :start, :next_round, :show_results, :process_results, :join]
+  before_action :set_game, only: [:show, :update, :destroy, :edit, :start, :next_round, :show_results, :process_results]
+  before_action :set_joinable_game, only: [:join]
   before_action :authenticate_user!, except: [:join]
 
   # GET /games
   def index
-    @games = Game.all.order(created_at: :desc)
+    @games = current_user.games.order(created_at: :desc)
   end
 
   # GET /games/1
@@ -24,7 +25,7 @@ class GamesController < ApplicationController
 
   # POST /games
   def create
-    @game = Game.new(game_params)
+    @game = current_user.games.new(game_params)
 
     respond_to do |format|
       if @game.save
@@ -115,6 +116,11 @@ class GamesController < ApplicationController
   private
 
   def set_game
+    @game = current_user.games.find(params[:id])
+  end
+
+  # `join` is the only unauthenticated entry point, so it can't scope by owner.
+  def set_joinable_game
     @game = Game.find(params[:id])
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,7 @@ class QuestionsController < ApplicationController
 
   # GET /questions
   def index
-    @questions = Question.all
+    @questions = Question.joins(round: :game).where(games: {user_id: current_user.id})
   end
 
   # GET /questions/1
@@ -57,6 +57,7 @@ class QuestionsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_question
     @question = Question.find(params[:id])
+    require_game_owner!(@question.round.game)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -42,6 +42,7 @@ class RoundsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_round
     @round = Round.find(params[:id])
+    require_game_owner!(@round.game)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/team_answers_controller.rb
+++ b/app/controllers/team_answers_controller.rb
@@ -15,6 +15,7 @@ class TeamAnswersController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_answer
     @team_answer = TeamAnswer.find(params[:id])
+    require_game_owner!(@team_answer.game)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,4 +1,5 @@
 class TeamsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_team, only: [:show, :update]
 
   # GET /teams/1
@@ -26,6 +27,7 @@ class TeamsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_team
     @team = Team.find(params[:id])
+    require_game_owner!(@team.game)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/models/concerns/relationship_updatable.rb
+++ b/app/models/concerns/relationship_updatable.rb
@@ -10,7 +10,7 @@ module RelationshipUpdatable
       relationship.last(relationship.count - amount).each(&:destroy!)
     elsif amount > relationship.count
       (amount - relationship.count).times do
-        relationship.create!(number: (relationship.last.number + 1))
+        relationship.create!(number: (relationship.maximum(:number) || 0) + 1)
       end
     end
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,8 @@
 class Game < ApplicationRecord
   include RelationshipUpdatable
 
+  belongs_to :user, optional: true
+
   has_many :rounds, -> { order(:number) }, dependent: :destroy
   has_many :teams, -> { order(:number) }, dependent: :destroy
 
@@ -36,7 +38,8 @@ class Game < ApplicationRecord
 
   def next_round!
     started! unless started?
-    current_round.finished! if current_round.present?
+    current_round&.finished!
+    return unless next_round.present?
     next_round.started!
     update!(current_round_number: (current_round_number + 1))
     broadcast_reload_teams
@@ -49,7 +52,7 @@ class Game < ApplicationRecord
   end
 
   def show_results!
-    finished! unless finished!
+    finished! unless finished?
     teams.each(&:update_total_points!)
     broadcast_reload_teams
   end
@@ -61,6 +64,7 @@ class Game < ApplicationRecord
   end
 
   def progress
+    return 0 if number_of_rounds.to_i.zero?
     100 / number_of_rounds
   end
 
@@ -87,11 +91,20 @@ end
 # Table name: games
 #
 #  id                   :uuid             not null, primary key
+#  current_round_number :integer          default(0)
 #  name                 :string
 #  number_of_rounds     :integer          default(3)
 #  number_of_teams      :integer          default(2)
-#  current_round_number :integer          default(0)
 #  status               :integer          default("pending_start")
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  user_id              :uuid
+#
+# Indexes
+#
+#  index_games_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -11,16 +11,16 @@ class Player
         name: name,
         game_id: game_id,
         team_id: team_id,
-        team_captian: team_captain
+        team_captain: team_captain
       },
-      expires_in: 24.hours,
-      )
+      expires_in: 24.hours
+    )
   end
 
   class << self
     def find(session_id, game_id)
       cache = Rails.cache.read(cache_key(session_id, game_id))
-      new(session_id: session_id,name: cache[:name], game_id: cache[:game_id], team_id: cache[:team_id], )
+      new(session_id: session_id, name: cache[:name], game_id: cache[:game_id], team_id: cache[:team_id], team_captain: cache[:team_captain])
     end
 
     def cache_key(session_id, game_id)

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -12,7 +12,7 @@ class Round < ApplicationRecord
   accepts_nested_attributes_for :questions
 
   def name
-    "Round #{number}: #{title}"
+    title.present? ? "Round #{number}: #{title}" : "Round #{number}"
   end
 
   def next_round

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,7 +6,7 @@ class Team < ApplicationRecord
   has_many :team_answers
   has_many :current_round_answers, ->(team) { includes(:question).where(question: team.game.current_round.questions).order("questions.number asc") }, class_name: "TeamAnswer"
 
-  validates_uniqueness_of :name, case_sensitive: false
+  validates_uniqueness_of :name, scope: :game_id, case_sensitive: false
 
   accepts_nested_attributes_for :team_answers
 

--- a/app/models/team_answer.rb
+++ b/app/models/team_answer.rb
@@ -12,6 +12,7 @@ class TeamAnswer < ApplicationRecord
   private
 
   def update_team_total_points
+    return if round.scored?
     round.scored!
     team.update_total_points!
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :timeoutable, :validatable
+
+  has_many :games, dependent: :destroy
 end
 
 # == Schema Information

--- a/app/views/games/join.html.slim
+++ b/app/views/games/join.html.slim
@@ -4,5 +4,3 @@
       .content
         h1.title = "Welcome to the game: #{@game.name}"
         == render 'components/form/notice', notice: notice
-        = "Session: #{session.id}"
-        = Redis.current.get "test"

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,9 +17,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: pubquiz
-  password: pubquiz
-  host: localhost
+  username: <%= ENV.fetch("PGUSER", "pubquiz") %>
+  password: <%= ENV.fetch("PGPASSWORD", "pubquiz") %>
+  host: <%= ENV.fetch("PGHOST", "localhost") %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,10 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = '0d563ca132e28dc36d58466f07b4f280234101199d03a6a205f83fe2c5b21c4c11ef1f410ae404ea2ba65d3d93b7ea3551796a4d79380d6f3b550476ad04c710'
+  # Devise defaults to `secret_key_base` (from encrypted credentials / ENV) when
+  # left unset. Do NOT hardcode a literal here — a committed key lets anyone with
+  # repo access forge reset/unlock/confirmation tokens.
+  # config.secret_key = Rails.application.credentials.devise_secret_key
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -24,7 +27,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'no-reply@pubquiz.org'
+  config.mailer_sender = "no-reply@pubquiz.org"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -36,7 +39,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -174,11 +177,11 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = {secure: !Rails.env.development?, httponly: true, same_site: :lax}
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 12..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -188,7 +191,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,11 +1,13 @@
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
-# end
+# This app uses no sensitive browser APIs — deny them all by default.
+Rails.application.config.permissions_policy do |f|
+  f.camera :none
+  f.gyroscope :none
+  f.microphone :none
+  f.usb :none
+  f.geolocation :none
+  f.payment :none
+  f.fullscreen :self
+end

--- a/db/migrate/20260615214633_add_user_to_games.rb
+++ b/db/migrate/20260615214633_add_user_to_games.rb
@@ -1,0 +1,7 @@
+class AddUserToGames < ActiveRecord::Migration[7.1]
+  def change
+    # Nullable: existing games predate ownership and have no creator to backfill.
+    # New games always set user_id (see GamesController#create).
+    add_reference :games, :user, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_194041) do
-
+ActiveRecord::Schema[7.1].define(version: 2026_06_15_214633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -22,8 +21,10 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.integer "number_of_teams", default: 2
     t.integer "current_round_number", default: 0
     t.integer "status", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["user_id"], name: "index_games_on_user_id"
   end
 
   create_table "questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -31,8 +32,8 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.integer "number", null: false
     t.text "question"
     t.text "answer"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["round_id"], name: "index_questions_on_round_id"
   end
 
@@ -40,8 +41,8 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.uuid "game_id", null: false
     t.integer "number", null: false
     t.integer "status", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "name"
     t.string "title"
     t.index ["game_id"], name: "index_rounds_on_game_id"
@@ -53,8 +54,8 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.text "answer"
     t.integer "status", default: 0
     t.float "points"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["question_id", "team_id"], name: "index_team_answers_on_question_id_and_team_id", unique: true
     t.index ["question_id"], name: "index_team_answers_on_question_id"
     t.index ["team_id"], name: "index_team_answers_on_team_id"
@@ -64,8 +65,8 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.uuid "game_id", null: false
     t.integer "number", null: false
     t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.float "total_points"
     t.index ["game_id", "name"], name: "index_teams_on_game_id_and_name", unique: true
     t.index ["game_id"], name: "index_teams_on_game_id"
@@ -89,14 +90,15 @@ ActiveRecord::Schema.define(version: 2021_05_11_194041) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "games", "users"
   add_foreign_key "questions", "rounds"
   add_foreign_key "rounds", "games"
   add_foreign_key "team_answers", "questions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,16 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Default login (idempotent).
-User.find_or_create_by!(email: "admin@example.com") do |u|
-  u.password = "password"
-  u.password_confirmation = "password"
-end
+# Default login (idempotent). Dev/test only — never seed a known-password
+# account into an environment that could reach production.
+if Rails.env.local?
+  password = ENV.fetch("SEED_ADMIN_PASSWORD", "changeme123!")
+  admin = User.find_or_create_by!(email: "admin@example.com") do |u|
+    u.password = password
+    u.password_confirmation = password
+  end
 
-# Game#update_rounds_and_teams (after_save) auto-creates the default
-# number_of_rounds rounds and number_of_teams teams.
-Game.create(name: "First pubquiz")
+  # Game#update_rounds_and_teams (after_save) auto-creates the default
+  # number_of_rounds rounds and number_of_teams teams.
+  Game.create(name: "First pubquiz", user: admin)
+end


### PR DESCRIPTION
## Context

Audit of the project surfaced authorization gaps (no ownership model — any logged-in user could read/mutate/destroy any game), committed secrets, and several logic bugs. This PR remediates the confirmed findings. Each was verified by reading source and exercising the model fixes in rolled-back transactions.

## Authorization / IDOR
- Add `user_id` to `games` (`belongs_to :user`); scope `GamesController` `index`/`create`/`set_game` to `current_user.games`; split the unauthenticated `join` into its own finder.
- Enforce game ownership on `teams`, `team_answers`, `rounds`, `questions` via `ApplicationController#require_game_owner!` (responds 404, no existence leak).
- Require `authenticate_user!` on `TeamsController`.
- Authenticate ActionCable connections via warden + `reject_unauthorized_connection`.

## Secrets / config hardening
- Remove committed Devise `secret_key` (falls back to `secret_key_base`). **Rotate the leaked key.**
- Enable `force_ssl` in production; raise `password_length` to 12; enable `timeoutable` + secure remember cookies; enable permissions policy.
- Move DB credentials to ENV (dev defaults preserved); gate seeds to local envs.
- Drop session-id leak + removed `Redis.current` call (crashed under redis-rb 5.x) from the join view.

## Logic fixes
- `Game#show_results!` double-negative guard; `Game#next_round!` no longer crashes past the last round; `Game#progress` guards divide-by-zero.
- `Team` name uniqueness scoped to `game_id`.
- `RelationshipUpdatable` uses `maximum(:number)` (avoids stale numbering).
- `TeamAnswer` scoring made idempotent; `Round#name` handles nil title; `Player` cache-key typo + lossy `find` fixed.

## Notes / follow-ups (not in this PR)
- Controller test suite was **already red** (28/28 errors — stale scaffold). New ownership behavior is untested; suite needs a rewrite.
- Pre-existing broadcast crash: `teams/_game_on.html.slim:4` calls `.name` on nil during round transitions.
- CSP left disabled (needs browser verification before enabling).
- Existing games have `user_id = nil` → inaccessible to owners (no creator to backfill).

## Test plan
- [x] `standardrb` clean on changed files
- [x] App eager-loads; routes resolve
- [x] Model fixes verified in rolled-back transactions (ownership, uniqueness scope, progress, next_round guard, numbering)
- [ ] Controller/auth specs (blocked on suite rewrite)