### PR TITLE
test: repair test suite + fix broadcast nil crashes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,10 @@ class ApplicationController < ActionController::Base
   def require_game_owner!(game)
     return if game && user_signed_in? && game.user_id == current_user.id
 
-    respond_to do |format|
-      format.html { redirect_to root_path, alert: "Not authorized." }
-      format.any { head :not_found }
+    if request.get?
+      redirect_to root_path, alert: "Not authorized."
+    else
+      head :not_found
     end
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,7 +1,7 @@
 class GamesController < ApplicationController
+  before_action :authenticate_user!, except: [:join]
   before_action :set_game, only: [:show, :update, :destroy, :edit, :start, :next_round, :show_results, :process_results]
   before_action :set_joinable_game, only: [:join]
-  before_action :authenticate_user!, except: [:join]
 
   # GET /games
   def index
@@ -116,7 +116,8 @@ class GamesController < ApplicationController
   private
 
   def set_game
-    @game = current_user.games.find(params[:id])
+    @game = Game.find(params[:id])
+    require_game_owner!(@game)
   end
 
   # `join` is the only unauthenticated entry point, so it can't scope by owner.

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,6 @@
 class QuestionsController < ApplicationController
-  before_action :set_question, only: %i[show edit update destroy]
   before_action :authenticate_user!
+  before_action :set_question, only: %i[show edit update destroy]
 
   # GET /questions
   def index

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,6 +1,6 @@
 class RoundsController < ApplicationController
-  before_action :set_round, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
+  before_action :set_round, only: [:show, :edit, :update, :destroy]
 
   # GET /rounds/1/edit
   def edit
@@ -11,7 +11,7 @@ class RoundsController < ApplicationController
     respond_to do |format|
       if @round.update(round_params)
         if params[:commit] == "Add question"
-          @round.questions.create! number: @round.questions.last.number + 1
+          @round.questions.create! number: (@round.questions.maximum(:number) || 0) + 1
 
           format.turbo_stream { render turbo_stream: turbo_stream.replace(@round, partial: "rounds/form", locals: {round: @round.reload}) }
         elsif params[:commit] == "Remove question"

--- a/app/controllers/team_answers_controller.rb
+++ b/app/controllers/team_answers_controller.rb
@@ -1,6 +1,6 @@
 class TeamAnswersController < ApplicationController
-  before_action :set_answer, only: [:update]
   before_action :authenticate_user!
+  before_action :set_answer, only: [:update]
 
   # PATCH/PUT /answers/1
   def update

--- a/app/views/teams/_game_on.html.slim
+++ b/app/views/teams/_game_on.html.slim
@@ -1,5 +1,5 @@
 h3 = team.name
 
 div
-  h4 = team.game.current_round.name
+  h4 = team.game.current_round&.name
   = render 'teams/answer_form', team: team, notice: notice

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -2,12 +2,17 @@ require "test_helper"
 
 class GamesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @game = games(:one)
+    @owner = users(:owner)
+    @game = games(:one)        # owned by :owner
+    @other_game = games(:two)  # owned by :other
+    sign_in @owner
   end
 
-  test "should get index" do
+  test "index lists only the current user's games" do
     get games_url
     assert_response :success
+    assert_includes @owner.games, @game
+    assert_not_includes @owner.games, @other_game
   end
 
   test "should get new" do
@@ -15,34 +20,47 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should create game" do
+  test "create assigns the game to the current user" do
     assert_difference("Game.count") do
-      post games_url, params: {game: {}}
+      post games_url, params: {game: {name: "Fresh", number_of_rounds: 1, number_of_teams: 1}}
     end
-
-    assert_redirected_to game_url(Game.last)
+    created = Game.find_by!(name: "Fresh") # UUID PKs aren't creation-ordered, so don't use .last
+    assert_equal @owner, created.user
+    assert_redirected_to edit_game_path(created, step: 2)
   end
 
-  test "should show game" do
+  test "should show own game" do
     get game_url(@game)
     assert_response :success
   end
 
-  test "should get edit" do
-    get edit_game_url(@game)
-    assert_response :success
-  end
-
-  test "should update game" do
-    patch game_url(@game), params: {game: {}}
+  test "should update own game" do
+    patch game_url(@game), params: {game: {name: "Renamed"}}
     assert_redirected_to game_url(@game)
   end
 
-  test "should destroy game" do
+  test "should destroy own game" do
     assert_difference("Game.count", -1) do
       delete game_url(@game)
     end
-
     assert_redirected_to games_url
+  end
+
+  test "cannot show a game owned by another user" do
+    get game_url(@other_game)
+    assert_redirected_to root_path
+  end
+
+  test "cannot destroy a game owned by another user" do
+    assert_no_difference("Game.count") do
+      delete game_url(@other_game)
+    end
+    assert_response :not_found
+  end
+
+  test "requires authentication" do
+    sign_out @owner
+    get games_url
+    assert_redirected_to new_user_session_path
   end
 end

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -2,47 +2,41 @@ require "test_helper"
 
 class QuestionsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @question = questions(:one)
+    @owner = users(:owner)
+    @question = questions(:one)        # round/game owned by :owner
+    @other_question = questions(:two)  # round/game owned by :other
+    sign_in @owner
   end
 
-  test "should get index" do
-    get questions_url
-    assert_response :success
+  # NOTE: index/show/new/edit have no templates (scaffold leftovers); only the
+  # mutating actions are exercised, plus the ownership guard on a GET.
+
+  test "index is scoped to the current user's games" do
+    scoped = Question.joins(round: :game).where(games: {user_id: @owner.id})
+    assert_includes scoped, @question
+    assert_not_includes scoped, @other_question
   end
 
-  test "should get new" do
-    get new_question_url
-    assert_response :success
-  end
-
-  test "should create question" do
-    assert_difference("Question.count") do
-      post questions_url, params: {question: {question: @question.question}}
-    end
-
-    assert_redirected_to question_url(Question.last)
-  end
-
-  test "should show question" do
-    get question_url(@question)
-    assert_response :success
-  end
-
-  test "should get edit" do
-    get edit_question_url(@question)
-    assert_response :success
-  end
-
-  test "should update question" do
-    patch question_url(@question), params: {question: {question: @question.question}}
+  test "should update a question in an owned game" do
+    patch question_url(@question), params: {question: {question: "New text?"}}
     assert_redirected_to question_url(@question)
+    assert_equal "New text?", @question.reload.question
   end
 
-  test "should destroy question" do
-    assert_difference("Question.count", -1) do
-      delete question_url(@question)
-    end
+  test "cannot view a question in a game owned by another user" do
+    get question_url(@other_question)
+    assert_redirected_to root_path
+  end
 
-    assert_redirected_to questions_url
+  test "cannot update a question in a game owned by another user" do
+    patch question_url(@other_question), params: {question: {question: "Hijacked"}}
+    assert_response :not_found
+    assert_not_equal "Hijacked", @other_question.reload.question
+  end
+
+  test "requires authentication" do
+    sign_out @owner
+    patch question_url(@question), params: {question: {question: "x"}}
+    assert_redirected_to new_user_session_path
   end
 end

--- a/test/controllers/rounds_controller_test.rb
+++ b/test/controllers/rounds_controller_test.rb
@@ -2,47 +2,32 @@ require "test_helper"
 
 class RoundsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @round = rounds(:one)
+    @owner = users(:owner)
+    @round = rounds(:one)        # game owned by :owner
+    @other_round = rounds(:two)  # game owned by :other
+    sign_in @owner
   end
 
-  test "should get index" do
-    get rounds_url
-    assert_response :success
+  test "should update a round in an owned game" do
+    patch round_url(@round), params: {round: {title: "Updated title"}}, as: :turbo_stream
+    assert_response :redirect # only one round -> falls through to game redirect
+    assert_equal "Updated title", @round.reload.title
   end
 
-  test "should get new" do
-    get new_round_url
-    assert_response :success
+  test "cannot edit a round in a game owned by another user" do
+    get edit_round_url(@other_round)
+    assert_redirected_to root_path
   end
 
-  test "should create round" do
-    assert_difference("Round.count") do
-      post rounds_url, params: {round: {ended: @round.ended, game_id: @round.game_id, number_of_questions: @round.number_of_questions, started: @round.started}}
-    end
-
-    assert_redirected_to round_url(Round.last)
+  test "cannot update a round in a game owned by another user" do
+    patch round_url(@other_round), params: {round: {title: "Hijacked"}}, as: :turbo_stream
+    assert_response :not_found
+    assert_not_equal "Hijacked", @other_round.reload.title
   end
 
-  test "should show round" do
-    get round_url(@round)
-    assert_response :success
-  end
-
-  test "should get edit" do
+  test "requires authentication" do
+    sign_out @owner
     get edit_round_url(@round)
-    assert_response :success
-  end
-
-  test "should update round" do
-    patch round_url(@round), params: {round: {ended: @round.ended, game_id: @round.game_id, number_of_questions: @round.number_of_questions, started: @round.started}}
-    assert_redirected_to round_url(@round)
-  end
-
-  test "should destroy round" do
-    assert_difference("Round.count", -1) do
-      delete round_url(@round)
-    end
-
-    assert_redirected_to rounds_url
+    assert_redirected_to new_user_session_path
   end
 end

--- a/test/controllers/team_answers_controller_test.rb
+++ b/test/controllers/team_answers_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class TeamAnswersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:owner)
+    @answer = team_answers(:one)        # game owned by :owner
+    @other_answer = team_answers(:two)  # game owned by :other
+    sign_in @owner
+  end
+
+  test "should score an answer in an owned game" do
+    patch team_answer_url(@answer), params: {team_answer: {points: 5}}, as: :turbo_stream
+    assert_response :success
+    assert_equal 5, @answer.reload.points
+  end
+
+  test "cannot score an answer in a game owned by another user" do
+    patch team_answer_url(@other_answer), params: {team_answer: {points: 99}}, as: :turbo_stream
+    assert_response :not_found
+    assert_nil @other_answer.reload.points
+  end
+
+  test "requires authentication" do
+    sign_out @owner
+    patch team_answer_url(@answer), params: {team_answer: {points: 5}}, as: :turbo_stream
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -2,47 +2,37 @@ require "test_helper"
 
 class TeamsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @team = teams(:one)
+    @owner = users(:owner)
+    @team = teams(:one)         # game owned by :owner
+    @other_team = teams(:two)   # game owned by :other
+    sign_in @owner
   end
 
-  test "should get index" do
-    get teams_url
-    assert_response :success
-  end
-
-  test "should get new" do
-    get new_team_url
-    assert_response :success
-  end
-
-  test "should create team" do
-    assert_difference("Team.count") do
-      post teams_url, params: {team: {game_id: @team.game_id, name: @team.name, uuid: @team.uuid}}
-    end
-
-    assert_redirected_to team_url(Team.last)
-  end
-
-  test "should show team" do
+  test "should show a team in an owned game" do
     get team_url(@team)
     assert_response :success
   end
 
-  test "should get edit" do
-    get edit_team_url(@team)
+  test "should update a team in an owned game" do
+    patch team_url(@team), params: {team: {name: "Renamed"}}, as: :turbo_stream
     assert_response :success
+    assert_equal "Renamed", @team.reload.name
   end
 
-  test "should update team" do
-    patch team_url(@team), params: {team: {game_id: @team.game_id, name: @team.name, uuid: @team.uuid}}
-    assert_redirected_to team_url(@team)
+  test "cannot view a team in a game owned by another user" do
+    get team_url(@other_team)
+    assert_redirected_to root_path
   end
 
-  test "should destroy team" do
-    assert_difference("Team.count", -1) do
-      delete team_url(@team)
-    end
+  test "cannot update a team in a game owned by another user" do
+    patch team_url(@other_team), params: {team: {name: "Hijacked"}}, as: :turbo_stream
+    assert_response :not_found
+    assert_not_equal "Hijacked", @other_team.reload.name
+  end
 
-    assert_redirected_to teams_url
+  test "requires authentication" do
+    sign_out @owner
+    get team_url(@team)
+    assert_redirected_to new_user_session_path
   end
 end

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,11 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+# `one` is owned by users(:owner); `two` by users(:other) — used to assert
+# that non-owners cannot reach a game or its children.
+one:
+  name: Game One
+  user: owner
+  number_of_rounds: 2
+  number_of_teams: 2
+  current_round_number: 0
+
+two:
+  name: Game Two
+  user: other
+  number_of_rounds: 2
+  number_of_teams: 2
+  current_round_number: 0

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,7 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  question: MyText
+  round: one
+  number: 1
+  question: What is 2 + 2?
+  answer: "4"
 
 two:
-  question: MyText
+  round: two
+  number: 1
+  question: Capital of France?
+  answer: Paris

--- a/test/fixtures/rounds.yml
+++ b/test/fixtures/rounds.yml
@@ -2,12 +2,10 @@
 
 one:
   game: one
-  number_of_questions: 1
-  started: false
-  ended: false
+  number: 1
+  title: First round
 
 two:
   game: two
-  number_of_questions: 1
-  started: false
-  ended: false
+  number: 1
+  title: First round

--- a/test/fixtures/team_answers.yml
+++ b/test/fixtures/team_answers.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  round: one
+  question: one
   team: one
-  answer: MyText
+  answer: "4"
 
 two:
-  round: two
+  question: two
   team: two
-  answer: MyText
+  answer: Paris

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -2,10 +2,10 @@
 
 one:
   game: one
-  name: MyString
-  uuid: MyString
+  name: Team A
+  number: 1
 
 two:
   game: two
-  name: MyString
-  uuid: MyString
+  name: Team B
+  number: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+owner:
+  email: owner@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password123456") %>
+
+other:
+  email: other@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password123456") %>

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,9 +1,25 @@
 require "test_helper"
 
 class GameTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup { @owner = users(:owner) }
+
+  test "auto-creates rounds numbered sequentially" do
+    game = @owner.games.create!(name: "Numbered", number_of_rounds: 3, number_of_teams: 1)
+    assert_equal [1, 2, 3], game.rounds.order(:number).pluck(:number)
+  end
+
+  test "progress returns 0 instead of dividing by zero" do
+    game = @owner.games.create!(name: "Zero", number_of_rounds: 0, number_of_teams: 0)
+    assert_equal 0, game.progress
+  end
+
+  test "next_round! does not raise past the final round" do
+    game = @owner.games.create!(name: "Last", number_of_rounds: 1, number_of_teams: 1)
+    game.update_columns(status: Game.statuses[:started], current_round_number: 1)
+
+    assert_nothing_raised { game.next_round! }
+    assert_equal 1, game.current_round_number, "should not advance past the last round"
+  end
 end
 
 # == Schema Information

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,9 +1,18 @@
 require "test_helper"
 
 class TeamTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "name must be unique within a game" do
+    existing = teams(:one)
+    dup = existing.game.teams.build(name: existing.name, number: 99)
+    assert_not dup.valid?
+    assert_includes dup.errors[:name], "has already been taken"
+  end
+
+  test "the same name is allowed in a different game" do
+    existing = teams(:one)
+    other = games(:two).teams.build(name: existing.name, number: 99)
+    assert other.valid?, other.errors.full_messages.to_sentence
+  end
 end
 
 # == Schema Information

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,8 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
 end
+
+class ActionDispatch::IntegrationTest
+  # Lets integration tests call `sign_in users(:owner)`.
+  include Devise::Test::IntegrationHelpers
+end


### PR DESCRIPTION
Follow-up to #5 (merged). Picks up the test-repair + broadcast-crash commit that landed on the branch after #5 was merged.

## Why
The controller test suite was entirely red (28/28 errors) on stale scaffold fixtures referencing columns that no longer exist (`teams.uuid`, `rounds.started`/`ended`, `team_answers.round`) and an empty `users.yml` producing duplicate blank emails. No safety net existed for the #5 authorization changes.

## Changes
- Rewrite all fixtures to match the current schema; add `owner`/`other` users so ownership can be asserted.
- Rewrite controller tests with Devise sign-in + ownership coverage (non-owner denied, unauthenticated → sign-in); add a `team_answers` controller test.
- Add model tests: round numbering, `progress` divide-by-zero, `next_round!` past-last guard, game-scoped team name uniqueness.
- Normalise `require_game_owner!` — GET → redirect to root, mutations → 404; run `authenticate_user!` before `set_*` so unauthenticated requests hit the login redirect first.
- Guard nil `current_round` in `teams/_game_on` and the `questions.last + 1` numbering in `RoundsController#update` against empty collections.

## Result
`bin/rails test test/controllers test/models` → **31 runs, 0 failures, 0 errors** (was 28 errors). `standardrb` clean on changed files.