### PR TITLE
build(lint): add RuboCop (StandardRB) pre-commit hook + editor integration

### DIFF
--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -2,7 +2,7 @@
 description: Lint with StandardRB
 ---
 
-Run `bundle exec standard`. If `$ARGUMENTS` contains `fix`, run `bundle exec standard --fix`
+Run `bundle exec standardrb`. If `$ARGUMENTS` contains `fix`, run `bundle exec standardrb --fix`
 instead and summarize what changed. Report remaining offenses concisely.
 
 `$ARGUMENTS`

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,16 @@
+{
+  "languages": {
+    "Ruby": {
+      "language_servers": ["ruby-lsp", "!rubocop", "!solargraph"],
+      "formatter": "language_server"
+    }
+  },
+  "lsp": {
+    "ruby-lsp": {
+      "initialization_options": {
+        "formatter": "standard",
+        "linters": ["standard"]
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,19 @@ bin/setup            # install deps + prepare DB
 bin/dev              # run web + JS watch (Procfile.dev)
 bin/rails test       # run Minitest suite (append a path to scope)
 bin/rails test:system # system tests (Capybara + Selenium)
-bundle exec standard # lint
-bundle exec standard --fix # autofix
+bundle exec standardrb # lint
+bundle exec standardrb --fix # autofix
 npm run build        # one-off JS build (bin/dev runs --watch)
 docker-compose up    # Postgres + Redis if not running locally
+bundle exec lefthook install # install git hooks (run once; bin/setup does it)
 ```
+
+## Git hooks
+
+- **lefthook** runs a **pre-commit** hook that lints staged `*.rb` files with StandardRB
+  (`bundle exec standardrb`). Config in `lefthook.yml`. Offenses block the commit.
+- Installed automatically by `bin/setup`; existing clones run `bundle exec lefthook install` once.
+- Bypass in a pinch with `git commit --no-verify`.
 
 ## Architecture & conventions
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   # Rails 7.1's test runner is incompatible with minitest 6; pin to 5.x.
   gem "minitest", "~> 5.25"
   gem "standard"
+  gem "lefthook", require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.4.9"
 
-gem 'bcrypt', '~> 3.1.7'
+gem "bcrypt", "~> 3.1.7"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise", "~> 4.9"
 gem "jsbundling-rails", "~> 1.3"
@@ -31,6 +31,7 @@ end
 
 group :development do
   gem "annotate"
+  gem "ruby-lsp", require: false
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "web-console", ">= 4.1.0"
   # Display performance information such as SQL time and flame graphs for each request in your browser.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -291,6 +295,10 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
+    ruby-lsp (0.26.9)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     rubyzip (3.4.0)
     sassc (2.4.0)
@@ -392,6 +400,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 7.1.0)
   redis (~> 5.0)
+  ruby-lsp
   sassc-rails (~> 2.1)
   selenium-webdriver (>= 4.11)
   slim (~> 4.1)
@@ -506,6 +515,7 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.30.0) sha256=743f11ed42f0a41a0341554087b077479fec7e2d47a7c123fd90a12c0db5e477
@@ -516,6 +526,7 @@ CHECKSUMS
   rubocop (1.87.0) sha256=b9d9ddf55116a513f8ef2c7ae660662d8b49301f118d3f0df61865b33a5c188d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  ruby-lsp (0.26.9) sha256=33a01c001c00a76b4e821efc04ed7572983430f31ca5d6f3e343d0b6ccab4129
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       railties (>= 6.0.0)
     json (2.19.9)
     language_server-protocol (3.17.0.5)
+    lefthook (2.1.9)
     lint_roller (1.1.0)
     listen (3.10.0)
       logger
@@ -383,6 +384,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise (~> 4.9)
   jsbundling-rails (~> 1.3)
+  lefthook
   listen (~> 3.3)
   minitest (~> 5.25)
   pg (~> 1.5)
@@ -449,6 +451,7 @@ CHECKSUMS
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lefthook (2.1.9) sha256=2d4d2e028d4ac4b265675c1180fe1f7c50230200630e65c3aff7d3ed90a1a334
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
+  puts "\n== Installing git hooks =="
+  system! 'bundle exec lefthook install'
+
   # Install JavaScript dependencies
   system! 'bin/yarn'
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  parallel: true
+  commands:
+    standard:
+      glob: "*.rb"
+      run: bundle exec standardrb {staged_files}
+      stage_fixed: true


### PR DESCRIPTION
## What

Enforce RuboCop on every commit and align the editor with the project's linter. The repo lints with **StandardRB** (a RuboCop wrapper); nothing ran it automatically until now.

## Changes

- **lefthook** added as a dev dependency with a `pre-commit` hook (`lefthook.yml`) that runs `bundle exec standardrb` on staged `*.rb` files. Offenses block the commit; bypass with `git commit --no-verify`.
- Hook installation wired into `bin/setup` (`bundle exec lefthook install`) so it is set up automatically.
- **ruby-lsp** added as a dev dependency; `.zed/settings.json` pins Zed's ruby-lsp to StandardRB for formatting and diagnostics — stops the editor surfacing default RuboCop offenses StandardRB does not enforce.
- Corrected the StandardRB invocation in `CLAUDE.md` and the `/lint` command: the gem's executable is `standardrb`, not `standard` (`bundle exec standard` failed with `command not found`).
- Documented the hook in `CLAUDE.md`.

## Verification

- `bundle exec lefthook install` writes `.git/hooks/pre-commit`.
- Staging a `.rb` file with a style offense and committing → hook blocks the commit.
- Staging only non-Ruby files → hook skips.
- `git commit --no-verify` bypasses the hook.
- Zed (ruby-lsp) diagnostics now match `bundle exec standardrb`.