### PR TITLE
feat(games): extract Game#start! into Games::StartGame interaction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.4.9"
 
+gem "active_interaction", "~> 5.5"
 gem "bcrypt", "~> 3.1.7"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_interaction (5.5.0)
+      activemodel (>= 5.2, < 9)
+      activesupport (>= 5.2, < 9)
     activejob (7.1.6)
       activesupport (= 7.1.6)
       globalid (>= 0.3.6)
@@ -385,6 +388,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_interaction (~> 5.5)
   annotate
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
@@ -418,6 +422,7 @@ CHECKSUMS
   actionpack (7.1.6) sha256=3fa42da36fdcfc3690a711ed35ac5d527b87d3d676f8d111238aa399151203eb
   actiontext (7.1.6) sha256=79d657422dd67cc8cb46866a7bec9d89ec8699f7fa5647c0eab3472dc0297e66
   actionview (7.1.6) sha256=11147d81f90465ae062b2a77805c6f8f446e044e309c51bd9449bdbd43edf566
+  active_interaction (5.5.0) sha256=394419f5357b6db09b65b9e711c2a37e1df1f719dace3cf7ff9830e5cee55082
   activejob (7.1.6) sha256=0dd9cd051d494608349dd9223a3e61c3933250db77e35ab6617c26c1d52dccbb
   activemodel (7.1.6) sha256=f72f510018a560b5969e3ffc88214441ff09eed60b310feba678a597b2a2e721
   activerecord (7.1.6) sha256=1aa298cd7fc97ed8639ebb05a46bd17243a1218d89945bdc2bac1e61e673f079

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -62,7 +62,7 @@ class GamesController < ApplicationController
   end
 
   def start
-    @game.start!
+    Games::StartGame.run!(game: @game)
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace(

--- a/app/interactions/application_interaction.rb
+++ b/app/interactions/application_interaction.rb
@@ -1,0 +1,2 @@
+class ApplicationInteraction < ActiveInteraction::Base
+end

--- a/app/interactions/games/start_game.rb
+++ b/app/interactions/games/start_game.rb
@@ -1,0 +1,23 @@
+module Games
+  class StartGame < ApplicationInteraction
+    object :game
+
+    def execute
+      game.started!
+      game.rounds.first.started!
+      game.update!(current_round_number: 1)
+      ensure_answers_exist
+      game.broadcast_reload_teams
+    end
+
+    private
+
+    def ensure_answers_exist
+      game.rounds.each do |round|
+        round.questions.each do |question|
+          game.teams.each { |team| question.team_answers.for_team(team) }
+        end
+      end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -21,21 +21,6 @@ class Game < ApplicationRecord
 
   broadcasts
 
-  def start!
-    started!
-    rounds.first.started!
-    update!(current_round_number: 1)
-    # make sure all answer objects are ready
-    rounds.each do |round|
-      round.questions.each do |question|
-        teams.each do |team|
-          question.team_answers.for_team(team)
-        end
-      end
-    end
-    broadcast_reload_teams
-  end
-
   def next_round!
     started! unless started?
     current_round&.finished!
@@ -74,11 +59,12 @@ class Game < ApplicationRecord
     end
   end
 
-  private
-
+  # Public so interactions (e.g. Games::StartGame) can trigger a team reload.
   def broadcast_reload_teams
     teams.reload.each { |team| team.reload.broadcast_replace_to team }
   end
+
+  private
 
   def update_rounds_and_teams
     update_relationship_to_amount(rounds, number_of_rounds)

--- a/test/interactions/games/start_game_test.rb
+++ b/test/interactions/games/start_game_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+module Games
+  class StartGameTest < ActiveSupport::TestCase
+    setup do
+      @owner = users(:owner)
+      @game = @owner.games.create!(name: "Startable", number_of_rounds: 2, number_of_teams: 2)
+    end
+
+    test "transitions the game and its first round to started" do
+      Games::StartGame.run!(game: @game)
+
+      assert @game.reload.started?
+      assert @game.rounds.first.started?
+      assert_equal 1, @game.current_round_number
+    end
+
+    test "ensures a team answer exists for every question and team" do
+      Games::StartGame.run!(game: @game)
+
+      @game.rounds.each do |round|
+        round.questions.each do |question|
+          @game.teams.each do |team|
+            assert question.team_answers.exists?(team: team),
+              "expected a TeamAnswer for question #{question.number} / team #{team.number}"
+          end
+        end
+      end
+    end
+
+    test "raises when given an invalid input" do
+      assert_raises(ActiveInteraction::InvalidInteractionError) do
+        Games::StartGame.run!(game: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Game-flow business logic lives as fat methods on the `Game` model (`start!`, `next_round!`, `process_results!`, `show_results!`). Each orchestrates across `Game → Round → Question → Team → TeamAnswer`, mutates state, and fires a broadcast. This PR introduces [`active_interaction`](https://github.com/AaronLasseigne/active_interaction) and applies it to the first, most representative candidate — the game-start flow — to establish the pattern.

## Changes

- Add `active_interaction` (`~> 5.5`)
- Add `ApplicationInteraction` base class
- Add `Games::StartGame` holding the start orchestration (state transition + pre-creating `TeamAnswer` records for every round/question/team + broadcast)
- Remove `Game#start!`; `GamesController#start` calls `Games::StartGame.run!(game: @game)` directly — logic leaves the model entirely
- Make `Game#broadcast_reload_teams` public so interactions can trigger team reloads
- Add `test/interactions/games/start_game_test.rb` (state transition, answer creation, invalid input)

## Why `start!` first

Richest showcase (state + nested record creation + broadcast), trivial controller seam (the action did nothing but delegate), and it had no unit test — so coverage gets added in the move. Confirmed via grep the controller was the only caller.

## Testing

- `bin/rails test test/interactions/games/start_game_test.rb test/models/game_test.rb` → 6 runs, 48 assertions, 0 failures
- `bundle exec standardrb` clean (also enforced by pre-commit hook)

## Follow-ups (separate PRs)

`next_round!`, `process_results!`, `show_results!` → matching interactions following this template; consider `Games::ScoreAnswer` to make the `TeamAnswer#after_update` callback chain explicit.