### PR TITLE
fix(teams): make team pages public, decouple from game owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-debug.log*
 
 # Personal (per-developer) Claude Code settings. Shared settings live in .claude/settings.json.
 /.claude/settings.local.json
+
+# Playwright MCP browser-check artifacts
+/.playwright-mcp/

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,4 @@
 class TeamsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_team, only: [:show, :update]
 
   # GET /teams/1
@@ -27,7 +26,6 @@ class TeamsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_team
     @team = Team.find(params[:id])
-    require_game_owner!(@team.game)
   end
 
   # Only allow a list of trusted parameters through.

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -2,37 +2,29 @@ require "test_helper"
 
 class TeamsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @owner = users(:owner)
     @team = teams(:one)         # game owned by :owner
     @other_team = teams(:two)   # game owned by :other
-    sign_in @owner
   end
 
-  test "should show a team in an owned game" do
+  test "should show a team" do
     get team_url(@team)
     assert_response :success
   end
 
-  test "should update a team in an owned game" do
+  test "should update a team" do
     patch team_url(@team), params: {team: {name: "Renamed"}}, as: :turbo_stream
     assert_response :success
     assert_equal "Renamed", @team.reload.name
   end
 
-  test "cannot view a team in a game owned by another user" do
+  test "shows a team without authentication" do
     get team_url(@other_team)
-    assert_redirected_to root_path
+    assert_response :success
   end
 
-  test "cannot update a team in a game owned by another user" do
-    patch team_url(@other_team), params: {team: {name: "Hijacked"}}, as: :turbo_stream
-    assert_response :not_found
-    assert_not_equal "Hijacked", @other_team.reload.name
-  end
-
-  test "requires authentication" do
-    sign_out @owner
-    get team_url(@team)
-    assert_redirected_to new_user_session_path
+  test "updates a team without authentication" do
+    patch team_url(@other_team), params: {team: {name: "Renamed"}}, as: :turbo_stream
+    assert_response :success
+    assert_equal "Renamed", @other_team.reload.name
   end
 end


### PR DESCRIPTION
## Context

Team pages during a game (`/teams/:id`) are meant to be **public** — a team should view its page and submit answers/edit its name without logging in. Today `TeamsController` gated both `show` and `update` behind the game **owner** via `require_game_owner!`, so only the host who created the game could touch a team. That coupling is wrong: teams aren't the host.

This removes the User↔Team permission link entirely so team pages are open. Per-team auth for invited team members will come later.

## Changes

- **`app/controllers/teams_controller.rb`** — drop `before_action :authenticate_user!` and remove `require_game_owner!(@team.game)` from `set_team`. Both `show` and `update` are now public.
- **`test/controllers/teams_controller_test.rb`** — rewrite to assert public access; drop the auth/ownership negative cases.

## Scope / what's untouched

- `teams#update` is the **team** acting (permits `:name`, `team_answers_attributes`), so it must be public too.
- **Host scoring lives in `TeamAnswersController#update`** (permits `:points`) and keeps `authenticate_user!` + `require_game_owner!` — unchanged.
- Team model has no `user` association; the link was purely the controller check.

## Verification

- `bin/rails test` green; StandardRB clean.
- Manual browser check (logged out): `/teams/:id` renders and answer submit persists; host game page still redirects to sign-in.