### PR TITLE
build(deps): upgrade Devise to 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "3.4.9"
 gem "active_interaction", "~> 5.5"
 gem "bcrypt", "~> 3.1.7"
 gem "bootsnap", ">= 1.4.4", require: false
-gem "devise", "~> 4.9"
+gem "devise", "~> 5.0"
 gem "jsbundling-rails", "~> 1.3"
 gem "pg", "~> 1.5"
 gem "puma", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,10 +106,10 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     drb (2.2.3)
@@ -387,7 +387,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
-  devise (~> 4.9)
+  devise (~> 5.0)
   jsbundling-rails (~> 1.3)
   lefthook
   listen (~> 3.3)
@@ -438,7 +438,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
-  devise (4.9.4) sha256=920042fe5e704c548aa4eb65ebdd65980b83ffae67feb32c697206bfd975a7f8
+  devise (5.0.4) sha256=d605f2b85854e74e56ee789e2d398702bc2d06e6bcd894717a670a3199c74cc1
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9


### PR DESCRIPTION
## Context

Bumps Devise **4.9.4 → 5.0.4**. Stacked on #14 (Rails 8.1) — targets `chore/upgrade-rails-8.1` so the diff shows only the Devise change.

The motivation is the known follow-up flagged in #14: Devise 4.9's `devise_for` emitted a `resource received a hash argument` deprecation under Rails 8.1 (removal in Rails 8.2). Devise 5 fixes it — after this bump the test boot is deprecation-free.

## Changes

- `Gemfile` — `devise` `~> 4.9` → `~> 5.0`
- `Gemfile.lock` — regenerated (devise 5.0.4)

**No application code changes.** Devise 5's removed APIs are all unused here:

- no `devise_error_messages!` (views use the `devise/shared/error_messages` partial)
- no `Devise::TestHelpers` (tests use `Devise::Test::IntegrationHelpers`)
- no `:bypass` option on `sign_in`, no positional-scope `sign_in(resource, :scope)`
- User model modules and `config/initializers/devise.rb` load unchanged

Ruby 3.4.9 / Rails 8.1.3 satisfy Devise 5's floors (Ruby ≥ 2.7, Rails ≥ 7.0).

## ⚠️ Operational note

Devise 5 drops `SecretKeyFinder` and derives `Devise.secret_key` from `secret_key_base`. **Reset-password / unlock tokens generated before this upgrade are invalidated** — any such links already in flight stop working and users must request new ones. No data migration required.

## Verification

- `Devise` version → `5.0.4`
- `bin/rails test` — 33 runs, 107 assertions, 0 failures, **0 deprecation warnings** (was 4 under 8.1)
- `bundle exec standardrb` — clean