### PR TITLE
feat(team_answers): extract scoring into Games::ScoreAnswer interaction

### DIFF
--- a/app/controllers/team_answers_controller.rb
+++ b/app/controllers/team_answers_controller.rb
@@ -4,7 +4,7 @@ class TeamAnswersController < ApplicationController
 
   # PATCH/PUT /answers/1
   def update
-    @team_answer.update(answer_params)
+    Games::ScoreAnswer.run!(team_answer: @team_answer, points: answer_params[:points])
     team = @team_answer.team
     round = @team_answer.round
     respond_to do |format|

--- a/app/interactions/games/score_answer.rb
+++ b/app/interactions/games/score_answer.rb
@@ -1,0 +1,22 @@
+module Games
+  class ScoreAnswer < ApplicationInteraction
+    object :team_answer, class: TeamAnswer
+    float :points, default: nil
+
+    def execute
+      team_answer.update!(points: points)
+      score_round_if_complete
+      team_answer
+    end
+
+    private
+
+    def score_round_if_complete
+      round = team_answer.round.reload
+      return if round.scored?
+      return unless round.all_answers_scored?
+      round.scored!
+      team_answer.team.update_total_points!
+    end
+  end
+end

--- a/app/models/team_answer.rb
+++ b/app/models/team_answer.rb
@@ -6,16 +6,6 @@ class TeamAnswer < ApplicationRecord
   has_one :game, through: :round
 
   enum :status, %i[pending correct incorrect], default: "pending"
-
-  after_update :update_team_total_points, if: proc { |answer| answer.round.all_answers_scored? }
-
-  private
-
-  def update_team_total_points
-    return if round.scored?
-    round.scored!
-    team.update_total_points!
-  end
 end
 
 # == Schema Information

--- a/app/views/games/index.html.slim
+++ b/app/views/games/index.html.slim
@@ -24,5 +24,3 @@
                       i.ml-2.fas.fa-border.fa-pen
                     = link_to game, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }
                       i.ml-1.fas.fa-border.fa-trash
-
-

--- a/test/interactions/games/score_answer_test.rb
+++ b/test/interactions/games/score_answer_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+module Games
+  class ScoreAnswerTest < ActiveSupport::TestCase
+    setup do
+      @owner = users(:owner)
+      @game = @owner.games.create!(name: "Scorable", number_of_rounds: 1, number_of_teams: 1)
+      Games::StartGame.run!(game: @game)
+      @round = @game.rounds.first
+      @team = @game.teams.first
+      @answers = @team.answers_for_round(@round).to_a
+    end
+
+    test "sets points on the answer" do
+      Games::ScoreAnswer.run!(team_answer: @answers.first, points: 3)
+
+      assert_equal 3, @answers.first.reload.points
+    end
+
+    test "scoring a non-final answer leaves the round unscored" do
+      Games::ScoreAnswer.run!(team_answer: @answers.first, points: 1)
+
+      refute @round.reload.scored?
+    end
+
+    test "scoring the last answer scores the round and updates team total" do
+      @answers.each { |answer| Games::ScoreAnswer.run!(team_answer: answer, points: 2) }
+
+      assert @round.reload.scored?
+      assert_equal @answers.size * 2, @team.reload.total_points
+    end
+
+    test "does not re-score an already scored round" do
+      @answers.each { |answer| Games::ScoreAnswer.run!(team_answer: answer, points: 2) }
+      total_after_first_pass = @team.reload.total_points
+
+      # Re-running on an answer in a scored round must not double-count.
+      Games::ScoreAnswer.run!(team_answer: @answers.first, points: 5)
+
+      assert_equal total_after_first_pass, @team.reload.total_points
+    end
+
+    test "raises when given an invalid input" do
+      assert_raises(ActiveInteraction::InvalidInteractionError) do
+        Games::ScoreAnswer.run!(team_answer: nil, points: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Scoring an answer used to silently cascade through a **hidden** `TeamAnswer#after_update` callback: when the last answer in a round got points, the callback marked the `Round` `scored!` and recomputed the `Team`'s `total_points`. Nothing at the call site (`TeamAnswersController#update`) revealed those cross-model side effects — the worst tangle of implicit logic in the app.

This is the second application of [`active_interaction`](https://github.com/AaronLasseigne/active_interaction), following `Games::StartGame` (#9). It makes the cascade explicit.

## Changes

- Add `Games::ScoreAnswer` — sets the answer's points, then (once every answer in the round is in) marks the round `scored` and refreshes the team total
- Remove the `after_update` callback from `TeamAnswer`; it's a plain record again
- `TeamAnswersController#update` calls `Games::ScoreAnswer.run!` directly
- Reload the round inside the guard so a stale cached `team_answer.round` association can't re-score a finished round or double-count points
- Add `test/interactions/games/score_answer_test.rb` (per-answer, round completion + team total, idempotency, invalid input)

## Note on the reload

The idempotency test surfaced a latent staleness bug: a cached `team_answer.round` association reported `scored? == false` after the round had already been scored, so re-running the interaction double-counted. Production was safe (each request loads `TeamAnswer` fresh), but the interaction is now robust regardless of caller via `team_answer.round.reload` in the guard.

## Testing

- `bin/rails test test/interactions/games test/models test/controllers` → 38 runs, 113 assertions, 0 failures
- `bundle exec standardrb` clean (also enforced by pre-commit hook)

## Follow-ups (separate PRs)

Remaining flow siblings — `next_round!`, `process_results!`, `show_results!` → matching `Games::*` interactions, following the StartGame/ScoreAnswer template.