### PR TITLE
feat(games): extract remaining flow methods into interactions

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -75,7 +75,7 @@ class GamesController < ApplicationController
   end
 
   def next_round
-    @game.next_round!
+    Games::AdvanceRound.run!(game: @game)
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace(
@@ -88,7 +88,7 @@ class GamesController < ApplicationController
   end
 
   def process_results
-    @game.process_results!
+    Games::ProcessResults.run!(game: @game)
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace(
@@ -101,7 +101,7 @@ class GamesController < ApplicationController
   end
 
   def show_results
-    @game.show_results!
+    Games::ShowResults.run!(game: @game)
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace(

--- a/app/interactions/games/advance_round.rb
+++ b/app/interactions/games/advance_round.rb
@@ -1,0 +1,14 @@
+module Games
+  class AdvanceRound < ApplicationInteraction
+    object :game
+
+    def execute
+      game.started! unless game.started?
+      game.current_round&.finished!
+      return unless game.next_round.present?
+      game.next_round.started!
+      game.update!(current_round_number: game.current_round_number + 1)
+      game.broadcast_reload_teams
+    end
+  end
+end

--- a/app/interactions/games/process_results.rb
+++ b/app/interactions/games/process_results.rb
@@ -1,0 +1,11 @@
+module Games
+  class ProcessResults < ApplicationInteraction
+    object :game
+
+    def execute
+      game.current_round.finished!
+      game.pending_results! unless game.pending_results?
+      game.broadcast_reload_teams
+    end
+  end
+end

--- a/app/interactions/games/show_results.rb
+++ b/app/interactions/games/show_results.rb
@@ -1,0 +1,11 @@
+module Games
+  class ShowResults < ApplicationInteraction
+    object :game
+
+    def execute
+      game.finished! unless game.finished?
+      game.teams.each(&:update_total_points!)
+      game.broadcast_reload_teams
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -21,27 +21,6 @@ class Game < ApplicationRecord
 
   broadcasts
 
-  def next_round!
-    started! unless started?
-    current_round&.finished!
-    return unless next_round.present?
-    next_round.started!
-    update!(current_round_number: (current_round_number + 1))
-    broadcast_reload_teams
-  end
-
-  def process_results!
-    current_round.finished!
-    pending_results! unless pending_results?
-    broadcast_reload_teams
-  end
-
-  def show_results!
-    finished! unless finished?
-    teams.each(&:update_total_points!)
-    broadcast_reload_teams
-  end
-
   def reset!
     update(current_round_number: 0, status: :pending_start)
     rounds.update_all(status: :pending_start)

--- a/test/interactions/games/advance_round_test.rb
+++ b/test/interactions/games/advance_round_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+module Games
+  class AdvanceRoundTest < ActiveSupport::TestCase
+    setup { @owner = users(:owner) }
+
+    test "advances to the next round and finishes the current one" do
+      game = @owner.games.create!(name: "Multi", number_of_rounds: 3, number_of_teams: 1)
+      Games::StartGame.run!(game: game)
+
+      Games::AdvanceRound.run!(game: game)
+
+      assert_equal 2, game.reload.current_round_number
+      assert game.rounds.find_by(number: 1).finished?
+      assert game.rounds.find_by(number: 2).started?
+    end
+
+    test "starts the game when it has not started yet" do
+      game = @owner.games.create!(name: "Cold", number_of_rounds: 2, number_of_teams: 1)
+
+      Games::AdvanceRound.run!(game: game)
+
+      assert game.reload.started?
+    end
+
+    test "does not advance past the final round" do
+      game = @owner.games.create!(name: "Last", number_of_rounds: 1, number_of_teams: 1)
+      game.update_columns(status: Game.statuses[:started], current_round_number: 1)
+
+      assert_nothing_raised { Games::AdvanceRound.run!(game: game) }
+      assert_equal 1, game.reload.current_round_number, "should not advance past the last round"
+    end
+
+    test "raises when given an invalid input" do
+      assert_raises(ActiveInteraction::InvalidInteractionError) do
+        Games::AdvanceRound.run!(game: nil)
+      end
+    end
+  end
+end

--- a/test/interactions/games/process_results_test.rb
+++ b/test/interactions/games/process_results_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+module Games
+  class ProcessResultsTest < ActiveSupport::TestCase
+    setup { @owner = users(:owner) }
+
+    test "finishes the current round and moves the game to pending_results" do
+      game = @owner.games.create!(name: "Pending", number_of_rounds: 2, number_of_teams: 1)
+      Games::StartGame.run!(game: game)
+
+      Games::ProcessResults.run!(game: game)
+
+      assert game.reload.pending_results?
+      assert game.rounds.find_by(number: 1).finished?
+    end
+
+    test "raises when given an invalid input" do
+      assert_raises(ActiveInteraction::InvalidInteractionError) do
+        Games::ProcessResults.run!(game: nil)
+      end
+    end
+  end
+end

--- a/test/interactions/games/show_results_test.rb
+++ b/test/interactions/games/show_results_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+module Games
+  class ShowResultsTest < ActiveSupport::TestCase
+    setup { @owner = users(:owner) }
+
+    test "finishes the game and recomputes team totals" do
+      game = @owner.games.create!(name: "Final", number_of_rounds: 1, number_of_teams: 1)
+      Games::StartGame.run!(game: game)
+      team = game.teams.first
+      team.team_answers.update_all(points: 2)
+
+      Games::ShowResults.run!(game: game)
+
+      assert game.reload.finished?
+      assert_equal team.team_answers.count * 2, team.reload.total_points
+    end
+
+    test "raises when given an invalid input" do
+      assert_raises(ActiveInteraction::InvalidInteractionError) do
+        Games::ShowResults.run!(game: nil)
+      end
+    end
+  end
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -12,14 +12,6 @@ class GameTest < ActiveSupport::TestCase
     game = @owner.games.create!(name: "Zero", number_of_rounds: 0, number_of_teams: 0)
     assert_equal 0, game.progress
   end
-
-  test "next_round! does not raise past the final round" do
-    game = @owner.games.create!(name: "Last", number_of_rounds: 1, number_of_teams: 1)
-    game.update_columns(status: Game.statuses[:started], current_round_number: 1)
-
-    assert_nothing_raised { game.next_round! }
-    assert_equal 1, game.current_round_number, "should not advance past the last round"
-  end
 end
 
 # == Schema Information


### PR DESCRIPTION
## Context

Completes the `active_interaction` migration of the game-flow logic begun by `Games::StartGame` (#9) and `Games::ScoreAnswer` (#17). The last three orchestration methods still living on the `Game` model move into single-purpose interactions, leaving the model with no flow logic at all.

## Changes

- `Games::AdvanceRound` — was `Game#next_round!`
- `Games::ProcessResults` — was `Game#process_results!`
- `Games::ShowResults` — was `Game#show_results!`
- `GamesController` actions call each interaction directly via `run!`
- Remove the three methods from `Game`; it now carries only `reset!`, `progress`, `results`, and broadcasts
- Migrate the existing `next_round!` model test to `Games::AdvanceRound`
- Add interaction tests for each (state transitions, team totals, the past-final-round guard, invalid input)

## Testing

- `bin/rails test test/interactions/games test/models test/controllers` → 40 runs, 118 assertions, 0 failures
- `bundle exec standardrb` clean (also enforced by pre-commit hook)

## Note on stacking

Branched off `main`, which already carries the gem + `ApplicationInteraction` base + `Games::StartGame`. Independent of the ScoreAnswer PR (#17).