### PR TITLE
fix(cable): Use correct redis url in cable settings

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
 
 test:
   adapter: test


### PR DESCRIPTION
###  What

Fixes the redis url in cable settings, to work with docker version